### PR TITLE
fix ngOnDestroy error

### DIFF
--- a/projects/angular-favicon/src/lib/angular-favicon.service.ts
+++ b/projects/angular-favicon/src/lib/angular-favicon.service.ts
@@ -79,6 +79,8 @@ export class AngularFaviconService implements OnDestroy {
   }
 
   ngOnDestroy() {
-    this.subscriptionToColorScheme.unsubscribe();
+    if (this.subscriptionToColorScheme) {
+      this.subscriptionToColorScheme.unsubscribe();
+    }
   }
 }


### PR DESCRIPTION
If you're not providing an altImageUrl, the subscription is never initialized, and the ngOnDestroy fails with `TypeError: Cannot read property 'unsubscribe' of undefined`